### PR TITLE
Fix OrganisationDetail view and link to TransactionList

### DIFF
--- a/OIPA/api/organisation/serializers.py
+++ b/OIPA/api/organisation/serializers.py
@@ -24,23 +24,15 @@ class OrganisationSerializer(BasicOrganisationSerializer):
             fields = ('code',)
 
     type = TypeSerializer()
-    reported_activities = serializers.HyperlinkedIdentityField(
-        source='activity_reporting_organisation',
+    reported_activities = EncodedHyperlinkedIdentityField(
         view_name='organisation-reported-activities')
-    participated_activities = serializers.HyperlinkedIdentityField(
-        source='activity_participating_organisation',
+    participated_activities = EncodedHyperlinkedIdentityField(
         view_name='organisation-participated-activities')
-
-    # These fields will need to be replaced once the TransactionSerializer
-    # is done
-    provided_transactions = serializers.PrimaryKeyRelatedField(
-        many=True,
-        queryset=iati.models.Transaction.objects.all(),
-        source='transaction_providing_organisation')
-    received_transactions = serializers.PrimaryKeyRelatedField(
-        many=True,
-        queryset=iati.models.Transaction.objects.all(),
-        source='transaction_receiving_organisation')
+    
+    provided_transactions = EncodedHyperlinkedIdentityField(
+        view_name='organisation-provided-transactions')
+    received_transactions = EncodedHyperlinkedIdentityField(
+        view_name='organisation-received-transactions')
 
     class Meta:
         model = iati.models.Organisation

--- a/OIPA/api/organisation/tests/test_organisation_serializers.py
+++ b/OIPA/api/organisation/tests/test_organisation_serializers.py
@@ -46,6 +46,20 @@ class TestCountrySerializers:
         for field in required_fields:
             assert field in serializer.data, msg.format(field)
 
+    def test_OrganisationDifficultNameSerializer(self):
+        difficult_name = u'"Campa\xc3\x83\xc6\x92\xc3\x82\xc2\xb1aGlobalporlaLibertaddeExpresi\xc3\x83\xc6\x92\xc3\x82\xc2\xb3nA19",Asociaci\xc3\x83\xc6\x92\xc3\x82\xc2\xb3nCivil'
+        organisation = iati_factory.OrganisationFactory.build(
+            code=difficult_name,
+            abbreviation='sc',
+            original_ref=' some code')
+        try:
+            serializer = serializers.OrganisationSerializer(
+                organisation,
+                context={'request': self.request_dummy})
+            serializer.data['reported_activities']
+        except Exception as e:
+            assert e is None, e
+
     def test_OrganisationTypeSerializer(self):
         type = iati_factory.OrganisationTypeFactory.build(
             code=10,

--- a/OIPA/api/organisation/views.py
+++ b/OIPA/api/organisation/views.py
@@ -6,6 +6,7 @@ from api.organisation import serializers
 from api.generics.views import DynamicListAPIView
 from api.generics.views import DynamicRetrieveAPIView
 from api.activity.views import ActivityList
+from api.transaction.views import TransactionList
 
 
 def custom_get_object(self):
@@ -14,6 +15,9 @@ def custom_get_object(self):
     OrganisationSerializer
     """
     queryset = self.filter_queryset(self.get_queryset())
+    return custom_get_object_from_queryset(self, queryset)
+
+def custom_get_object_from_queryset(self, queryset):
     lookup_url_kwarg = self.lookup_url_kwarg or self.lookup_field
     lookup_url = self.kwargs[lookup_url_kwarg]
 
@@ -35,36 +39,31 @@ class OrganisationDetail(DynamicRetrieveAPIView):
 
 
 class ParticipatedActivities(ActivityList):
-    get_object = custom_get_object
 
     def get_queryset(self):
-        pk = self.kwargs.get('pk')
-        organisation = iati.models.Organisation.objects.get(pk=pk)
+        organisation = custom_get_object_from_queryset(self,
+            iati.models.Organisation.objects.all())
         return organisation.activity_set.all()
 
 
 class ReportedActivities(ActivityList):
-    get_object = custom_get_object
-
     def get_queryset(self):
-        pk = self.kwargs.get('pk')
-        organisation = iati.models.Organisation.objects.get(pk=pk)
+        organisation = custom_get_object_from_queryset(self,
+            iati.models.Organisation.objects.all())
         return organisation.activity_reporting_organisation.all()
 
 
-class ProvidedTransactions(generics.ListAPIView):
-    get_object = custom_get_object
+class ProvidedTransactions(TransactionList):
 
     def get_queryset(self):
-        pk = self.kwargs.get('pk')
-        organisation = iati.models.Organisation.objects.get(pk=pk)
+        organisation = custom_get_object_from_queryset(self,
+            iati.models.Organisation.objects.all())
         return organisation.transaction_providing_organisation.all()
 
 
-class ReceivedTransactions(ActivityList):
-    get_object = custom_get_object
+class ReceivedTransactions(TransactionList):
 
     def get_queryset(self):
-        pk = self.kwargs.get('pk')
-        organisation = iati.models.Organisation.objects.get(pk=pk)
+        organisation = custom_get_object_from_queryset(self,
+            iati.models.Organisation.objects.all())
         return organisation.transaction_receiving_organisation.all()


### PR DESCRIPTION
Organisation links to TransactionList

get_object is no longer specified when the view returns anything other than Organisation (e.g. activities).
custom_get_object_from_queryset is used to specify a different queryset than self.get_queryset().

fixes #129 