### PR TITLE
Added fabfile and updated doc

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,14 @@ vagrant ssh
 ./manage.py runserver 0.0.0.0:8080
 ```
 
+Or install fabric locally: `sudo pip install fabric`
+
+and run:
+
+```#!bash
+fab serve
+```
+
 and open your browser at `http://localhost:19088/`.
 
 This setup includes supervisor runnning on background, log is stored at `/vagrant/OIPA/static/supervisor.log`.

--- a/fabfile.py
+++ b/fabfile.py
@@ -1,0 +1,33 @@
+import re
+from fabric.api import local
+from fabric.api import run
+from fabric.api import env
+
+
+def get_oipa_port():
+    """
+    Get OIPA ssh port from `vagrant ssh-config` command
+    """
+    result = local('vagrant ssh-config', capture=True)
+    for line in result.split('\n'):
+        match = re.findall(' Port (?P<port>\d+)', line)
+        if len(match):
+            return match[0]
+    return None
+
+
+def serve():
+    """
+    Serve django dev server on localhost:19088
+    """
+
+    port = get_oipa_port()
+
+    if port is None:
+        print("Can not find OIPA instance port. Abort.")
+        return
+
+    env.password = 'vagrant'
+    env.use_ssh_config = True
+    env.host_string = "vagrant@127.0.0.1:{port}".format(port=port)
+    run('/home/vagrant/.env/bin/python /vagrant/OIPA/manage.py runserver 0.0.0.0:8080')


### PR DESCRIPTION
In order to simplify local development I've added fabfile to setup.

Now you can run local `fab serve` to start django dev server on vagrant box.