### PR TITLE
Make result__title search work on required v3 endpoints

### DIFF
--- a/OIPA/api/activity/serializers.py
+++ b/OIPA/api/activity/serializers.py
@@ -505,7 +505,7 @@ class ActivitySerializer(DynamicFieldsModelSerializer):
     document_links = DocumentLinkSerializer(
         many=True,
         source='documentlink_set')
-    results = ResultSerializer(many=True, source='result_set')
+    results = ResultSerializer(many=True)
     locations = LocationSerializer(many=True, source='location_set')
 
     class Meta:

--- a/OIPA/api/v3/resources/activity_view_resources.py
+++ b/OIPA/api/v3/resources/activity_view_resources.py
@@ -155,6 +155,9 @@ class ActivityResultResource(ModelResource):
         queryset = Result.objects.all()
         include_resource_uri = False
         excludes = ['id']
+        filtering = {
+            'title': ALL
+        }
 
 
 class RelatedActivityResource(ModelResource):
@@ -188,7 +191,7 @@ class ActivityResource(ModelResource):
     documents = fields.ToManyField(DocumentResource, 'documentlink_set', full=True, null=True, use_in='detail')
     other_identifier = fields.ToManyField(OtherIdentifierResource, 'otheridentifier_set', full=True, null=True, use_in='detail')
     locations = fields.ToManyField(ActivityLocationResource, 'location_set', full=True, null=True, use_in='all')
-    results = fields.ToManyField(ActivityResultResource, 'result_set', full=True, null=True, use_in='detail')
+    results = fields.ToManyField(ActivityResultResource, 'results', full=True, null=True, use_in='all')
     related_activities = fields.ToManyField(RelatedActivityResource, 'related_activities', full=True, null=True, use_in='detail')
 
     # to add:
@@ -224,7 +227,8 @@ class ActivityResource(ModelResource):
             'regions': ('exact', 'in'),
             'countries': ('exact', 'in'),
             'reporting_organisation': ('exact', 'in'),
-            'documents': ALL_WITH_RELATIONS
+            'documents': ALL_WITH_RELATIONS,
+            'results': ALL_WITH_RELATIONS
         }
         cache = NoTransformCache()
         paginator_class = NoCountPaginator

--- a/OIPA/api/v3/resources/activity_view_resources.py
+++ b/OIPA/api/v3/resources/activity_view_resources.py
@@ -156,7 +156,7 @@ class ActivityResultResource(ModelResource):
         include_resource_uri = False
         excludes = ['id']
         filtering = {
-            'title': ALL
+            'title': 'exact',
         }
 
 
@@ -191,7 +191,7 @@ class ActivityResource(ModelResource):
     documents = fields.ToManyField(DocumentResource, 'documentlink_set', full=True, null=True, use_in='detail')
     other_identifier = fields.ToManyField(OtherIdentifierResource, 'otheridentifier_set', full=True, null=True, use_in='detail')
     locations = fields.ToManyField(ActivityLocationResource, 'location_set', full=True, null=True, use_in='all')
-    results = fields.ToManyField(ActivityResultResource, 'results', full=True, null=True, use_in='all')
+    results = fields.ToManyField(ActivityResultResource, 'result_set', full=True, null=True, use_in='all')
     related_activities = fields.ToManyField(RelatedActivityResource, 'related_activities', full=True, null=True, use_in='detail')
 
     # to add:

--- a/OIPA/api/v3/resources/activity_view_resources.py
+++ b/OIPA/api/v3/resources/activity_view_resources.py
@@ -191,7 +191,7 @@ class ActivityResource(ModelResource):
     documents = fields.ToManyField(DocumentResource, 'documentlink_set', full=True, null=True, use_in='detail')
     other_identifier = fields.ToManyField(OtherIdentifierResource, 'otheridentifier_set', full=True, null=True, use_in='detail')
     locations = fields.ToManyField(ActivityLocationResource, 'location_set', full=True, null=True, use_in='all')
-    results = fields.ToManyField(ActivityResultResource, 'result_set', full=True, null=True, use_in='all')
+    results = fields.ToManyField(ActivityResultResource, 'results', full=True, null=True, use_in='all')
     related_activities = fields.ToManyField(RelatedActivityResource, 'related_activities', full=True, null=True, use_in='detail')
 
     # to add:

--- a/OIPA/api/v3/resources/aggregation_resources.py
+++ b/OIPA/api/v3/resources/aggregation_resources.py
@@ -3,7 +3,7 @@ from tastypie.resources import ModelResource
 
 # cache specific
 from api.cache import NoTransformCache
-from iati.models import AidType
+from iati.models import Activity
 
 # Direct sql specific
 import ujson
@@ -16,8 +16,7 @@ from api.v3.resources.custom_call_helper import CustomCallHelper
 class ActivityAggregatedAnyResource(ModelResource):
 
     class Meta:
-        #aid_type is used as dummy
-        queryset = AidType.objects.all()
+        queryset = Activity.objects.none()
         resource_name = 'activity-aggregate-any'
         include_resource_uri = True
         cache = NoTransformCache()
@@ -27,53 +26,106 @@ class ActivityAggregatedAnyResource(ModelResource):
     def get_list(self, request, **kwargs):
 
         # get group by and aggregation pars
-        group_by_key = request.GET.get("group_by", None) # valid : country, region, year, sector, reporting org
-        aggregation_key = request.GET.get("aggregation_key", "iati-identifier")
-        group_field = request.GET.get("group_field", "start_actual") # used for year filtering, valid : start_planned, start_actual, end_planned, end_actual, defaults to start_actual
+        group_by_key = request.GET.get('group_by', None)
+        aggregation_key = request.GET.get('aggregation_key', 'iati-identifier')
+        group_field = request.GET.get('group_field', 'start_actual')
+        query = request.GET.get('query', '')
+
         if group_by_key in {'commitment', 'disbursement', 'incoming-fund'}:
-            group_field = "t.value_date"
+            group_field = 't.value_date'
 
         aggregation_element_dict = {
-            'iati-identifier': {'select': 'a.id', 'type': 'count', 'from_addition': ''},
-            'reporting-org': {'select': 'a.reporting_organisation_id', 'type': 'count', 'from_addition': ''},
-            'title': {'select': 't.title', 'type': 'count', 'from_addition': 'JOIN iati_title as t on a.id = t.activity_id '},
-            'description': {'select': 'd.description', 'type': 'count', 'from_addition':'JOIN iati_description as d on a.id = d.activity_id '},
-            'commitment': {'select': 't.value', 'type': 'sum', 'from_addition': 'JOIN iati_transaction as t on a.id = t.activity_id ', 'where_addition': 'AND t.transaction_type_id = "C" '},
-            'disbursement': {'select': 't.value', 'type': 'sum', 'from_addition': 'JOIN iati_transaction as t on a.id = t.activity_id ', 'where_addition': 'AND t.transaction_type_id = "D" '},
-            'expenditure': {'select': 't.value', 'type': 'sum', 'from_addition': 'JOIN iati_transaction as t on a.id = t.activity_id ', 'where_addition': 'AND t.transaction_type_id = "E" '},
-            'incoming-fund': {'select': 't.value', 'type': 'sum', 'from_addition': 'JOIN iati_transaction as t on a.id = t.activity_id ', 'where_addition': 'AND t.transaction_type_id = "IF" '},
-            'location': {'select': 'l.activity_id', 'type': 'count', 'from_addition': 'JOIN iati_location as l on a.id = l.activity_id '},
-            'policy-marker': {'select': 'pm.policy_marker_id', 'type': 'count', 'from_addition': 'JOIN iati_activitypolicymarker as pm on a.id = pm.activity_id '},
-            'total-budget': {'select': 'a.total_budget', 'type': 'sum', 'from_addition': ''},
-            # 'recipient-country': {'select': 'a.id', 'type': 'count', 'from_addition': ''},
-            # 'recipient-region': {'select': 'a.id', 'type': 'count', 'from_addition': ''},
-            # 'year': {'select': 'a.id', 'type': 'count', 'from_addition': ''},
-            # 'sector': {'select': 'a.id', 'type': 'count', 'from_addition': ''},
+            'iati-identifier': {
+                'select': 'a.id',
+                'type': 'count',
+                'from_addition': ''},
+            'reporting-org': {
+                'select': 'a.reporting_organisation_id',
+                'type': 'count',
+                'from_addition': ''},
+            'title': {
+                'select': 't.title',
+                'type': 'count',
+                'from_addition': 'JOIN iati_title as t on a.id = t.activity_id '},
+            'description': {
+                'select': 'd.description',
+                'type': 'count',
+                'from_addition': 'JOIN iati_description as d on a.id = d.activity_id '},
+            'commitment': {
+                'select': 't.value',
+                'type': 'sum',
+                'from_addition': 'JOIN iati_transaction as t on a.id = t.activity_id ',
+                'where_addition': 'AND t.transaction_type_id = "C" '},
+            'disbursement': {
+                'select': 't.value',
+                'type': 'sum',
+                'from_addition': 'JOIN iati_transaction as t on a.id = t.activity_id ',
+                'where_addition': 'AND t.transaction_type_id = "D" '},
+            'expenditure': {
+                'select': 't.value',
+                'type': 'sum',
+                'from_addition': 'JOIN iati_transaction as t on a.id = t.activity_id ',
+                'where_addition': 'AND t.transaction_type_id = "E" '},
+            'incoming-fund': {
+                'select': 't.value',
+                'type': 'sum',
+                'from_addition': 'JOIN iati_transaction as t on a.id = t.activity_id ',
+                'where_addition': 'AND t.transaction_type_id = "IF" '},
+            'location': {
+                'select': 'l.activity_id',
+                'type': 'count',
+                'from_addition': 'JOIN iati_location as l on a.id = l.activity_id '},
+            'policy-marker': {
+                'select': 'pm.policy_marker_id',
+                'type': 'count',
+                'from_addition': 'JOIN iati_activitypolicymarker as pm on a.id = pm.activity_id '},
+            'total-budget': {
+                'select': 'a.total_budget',
+                'type': 'sum',
+                'from_addition': ''},
         }
 
         group_by_element_dict = {
-            'recipient-country': {'select': 'rc.country_id', 'from_addition': 'JOIN iati_activityrecipientcountry as rc on a.id = rc.activity_id '},
-            'recipient-region': {'select': 'r.name, rr.region_id', 'from_addition': 'JOIN iati_activityrecipientregion as rr on a.id = rr.activity_id join geodata_region as r on rr.region_id = r.code '},
-            'year': {'select': 'YEAR('+group_field+')', 'from_addition': ''},
-            'sector': {'select': 'acts.sector_id', 'from_addition': 'JOIN iati_activitysector as acts on a.id = acts.activity_id '},
-            'reporting-org': {'select': 'a.reporting_organisation_id', 'from_addition': ''},
-            'participating-org': {'select': 'po.name', 'from_addition': 'JOIN iati_activityparticipatingorganisation as po on a.id = po.activity_id '},
-            'policy-marker': {'select': 'pm.policy_marker_id', 'from_addition': 'JOIN iati_activitypolicymarker as pm on a.id = pm.activity_id '},
+            'recipient-country': {
+                'select': 'rc.country_id',
+                'from_addition': 'JOIN iati_activityrecipientcountry as rc on a.id = rc.activity_id '},
+            'recipient-region': {
+                'select': 'r.name, rr.region_id',
+                'from_addition': 'JOIN iati_activityrecipientregion as rr on a.id = rr.activity_id '
+                                 'join geodata_region as r on rr.region_id = r.code '},
+            'year': {
+                'select': 'YEAR('+group_field+')',
+                'from_addition': ''},
+            'sector': {
+                'select': 'acts.sector_id',
+                'from_addition': 'JOIN iati_activitysector as acts on a.id = acts.activity_id '},
+            'reporting-org': {
+                'select': 'a.reporting_organisation_id',
+                'from_addition': ''},
+            'participating-org': {
+                'select': 'po.name',
+                'from_addition': 'JOIN iati_activityparticipatingorganisation as po on a.id = po.activity_id '},
+            'policy-marker': {
+                'select': 'pm.policy_marker_id',
+                'from_addition': 'JOIN iati_activitypolicymarker as pm on a.id = pm.activity_id '},
+            'r.title': {
+                'select': 'r.title',
+                'from_addition': 'JOIN iati_result as r on a.id = r.activity_id ',
+                'where_addition': ' AND r.title = %(query)s '},
         }
 
         helper = CustomCallHelper()
         cursor = connection.cursor()
 
         # get filters
-        reporting_organisations = helper.get_and_query(request, 'reporting_organisation__in', 'a.reporting_organisation_id')
+        reporting_organisations = helper.get_and_query(
+            request,
+            'reporting_organisation__in',
+            'a.reporting_organisation_id')
         recipient_countries = helper.get_and_query(request, 'countries__in', 'rc.country_id')
         recipient_regions = helper.get_and_query(request, 'regions__in', 'rr.region_id')
         total_budgets = helper.get_and_query(request, 'total_budget__in', 'a.total_budget')
         sectors = helper.get_and_query(request, 'sectors__in', 'acts.sector_id')
-
-
-
-
 
         if aggregation_key in aggregation_element_dict:
             aggregation_info = aggregation_element_dict[aggregation_key]
@@ -84,71 +136,94 @@ class ActivityAggregatedAnyResource(ModelResource):
             if "where_addition" in aggregation_info:
                 aggregation_where_addition = aggregation_info["where_addition"]
         else:
-
-            return HttpResponse(ujson.dumps({"error": "Invalid aggregation key, see included list for viable keys.","valid_aggregation_keys": list(aggregation_element_dict.keys())}), content_type='application/json')
+            return HttpResponse(ujson.dumps({
+                "error": "Invalid aggregation key, see included list for viable keys.",
+                "valid_aggregation_keys": list(aggregation_element_dict.keys())}),
+                content_type='application/json')
 
         if group_by_key in group_by_element_dict:
             group_by_info = group_by_element_dict[group_by_key]
             group_select = group_by_info["select"]
             group_from_addition = group_by_info["from_addition"]
+            if "where_addition" in group_by_info and query:
+                aggregation_where_addition = aggregation_where_addition.join(group_by_info["where_addition"])
         else:
-            return HttpResponse(ujson.dumps({"error": "Invalid group by key, see included list for viable keys.","valid_group_by_keys": list(group_by_element_dict.keys())}), content_type='application/json')
+            return HttpResponse(ujson.dumps({
+                "error": "Invalid group by key, see included list for viable keys.",
+                "valid_group_by_keys": list(group_by_element_dict.keys())}),
+                content_type='application/json')
 
         # make sure group key and aggregation key are set
         if not group_by_key:
-            return HttpResponse(ujson.dumps("No field to group by. add parameter group_by (country/region/etc.. see docs)"), content_type='application/json')
-        if not aggregation_key:
-            return HttpResponse(ujson.dumps("No field to aggregate on. add parameter aggregation_key (iati-identifier/reporting-org/etc.. see docs)"), content_type='application/json')
+            return HttpResponse(ujson.dumps(
+                "No field to group by. add parameter group_by (country/region/etc.. see docs)"),
+                content_type='application/json')
 
-        #create the query
-        query_select = 'SELECT '+aggregation_type+'(' + aggregation_key + ') as aggregation_field, ' + group_select + ' as group_field '
-        query_from = 'FROM iati_activity as a ' + aggregation_from_addition + group_from_addition
-        query_where = 'WHERE 1 ' + aggregation_where_addition
-        query_group_by = 'GROUP BY ' + group_select
+        if not aggregation_key:
+            return HttpResponse(ujson.dumps(
+                "No field to aggregate on. add parameter aggregation_key "),
+                content_type='application/json')
+
+        query_select = ''.join([
+            'SELECT ',
+            aggregation_type,
+            '(',
+            aggregation_key,
+            ') as aggregation_field, ',
+            group_select,
+            ' as group_field '])
+
+        query_from = ''.join([
+            'FROM iati_activity as a ',
+            aggregation_from_addition,
+            group_from_addition])
+
+        query_where = ''.join([
+            'WHERE 1 ',
+            aggregation_where_addition])
+
+        query_group_by = ''.join([
+            'GROUP BY ',
+            group_select])
 
         # fill where part
-        filter_string = 'AND (' + reporting_organisations + recipient_countries + recipient_regions + total_budgets + sectors + ')'
+        filter_string = ''.join([
+            'AND (',
+            reporting_organisations,
+            recipient_countries,
+            recipient_regions,
+            total_budgets,
+            sectors,
+            ')'])
+
         if filter_string == 'AND ()':
             filter_string = ""
-        else:
-            if 'AND ()' in filter_string:
-                filter_string = filter_string[:-6]
+        elif 'AND ()' in filter_string:
+            filter_string = filter_string[:-6]
 
         query_where += filter_string
 
-        # optimalisation for simple (all) queries
         if not filter_string and query_from == 'FROM iati_activity as a ':
-            if(group_by_key == "country"):
+            if group_by_key == "country":
                 query_select = 'SELECT count(activity_id) as aggregation_field, country_id as group_field '
                 query_from = "FROM iati_activityrecipientcountry "
                 query_group_by = "GROUP BY country_id"
 
-            elif(group_by_key == "region"):
+            elif group_by_key == "region":
                 query_select = 'SELECT count(activity_id) as aggregation_field, region_id as group_field '
                 query_from = "FROM iati_activityrecipientregion "
                 query_group_by = "GROUP BY region_id"
 
-            elif(group_by_key == "sector"):
+            elif group_by_key == "sector":
                 query_select = 'SELECT count(activity_id) as aggregation_field, sector_id as group_field '
                 query_from = "FROM iati_activitysector "
                 query_group_by = "GROUP BY sector_id"
 
-        # execute query
-        cursor.execute(query_select + query_from + query_where + query_group_by)
+        cursor.execute(query_select + query_from + query_where + query_group_by, {"query": query, })
         results1 = helper.get_fields(cursor=cursor)
 
-        # query result -> json output
-
         options = []
-
         for r in results1:
-
-
-
             options.append(r)
-
-            # options[r['group_field']] = r['aggregation_field']
-
-
 
         return HttpResponse(ujson.dumps(options), content_type='application/json')

--- a/OIPA/iati/activity_manager.py
+++ b/OIPA/iati/activity_manager.py
@@ -44,6 +44,10 @@ class ActivityQuerySet(query.QuerySet):
                 'name': 'activitysearchdata__search_documentlink_title',
                 'method': '__search'
             },
+            'results': {
+                'name': 'result__title',
+                'method': ''
+            },
         }
 
     def search(self, query, search_fields):

--- a/OIPA/iati/activity_manager.py
+++ b/OIPA/iati/activity_manager.py
@@ -45,7 +45,7 @@ class ActivityQuerySet(query.QuerySet):
                 'method': '__search'
             },
         }
-    
+
     def search(self, query, search_fields):
         prepared_filter = self._prepare_search_filter(
             self.Meta.DEFAULT_SEARCH_FIELDS if search_fields is None

--- a/OIPA/iati/activity_manager.py
+++ b/OIPA/iati/activity_manager.py
@@ -44,12 +44,8 @@ class ActivityQuerySet(query.QuerySet):
                 'name': 'activitysearchdata__search_documentlink_title',
                 'method': '__search'
             },
-            'results': {
-                'name': 'result__title',
-                'method': ''
-            },
         }
-
+    
     def search(self, query, search_fields):
         prepared_filter = self._prepare_search_filter(
             self.Meta.DEFAULT_SEARCH_FIELDS if search_fields is None

--- a/OIPA/iati/models.py
+++ b/OIPA/iati/models.py
@@ -660,7 +660,7 @@ class DocumentLink(models.Model):
 
 
 class Result(models.Model):
-    activity = models.ForeignKey(Activity)
+    activity = models.ForeignKey(Activity, related_name="results")
     result_type = models.ForeignKey(ResultType, null=True, default=None)
     title = models.CharField(max_length=255, default="")
     description = models.TextField(default="")

--- a/OIPA/iati/models.py
+++ b/OIPA/iati/models.py
@@ -660,7 +660,7 @@ class DocumentLink(models.Model):
 
 
 class Result(models.Model):
-    activity = models.ForeignKey(Activity, related_name="results")
+    activity = models.ForeignKey(Activity, related_name="result_set")
     result_type = models.ForeignKey(ResultType, null=True, default=None)
     title = models.CharField(max_length=255, default="")
     description = models.TextField(default="")

--- a/OIPA/iati/models.py
+++ b/OIPA/iati/models.py
@@ -660,7 +660,7 @@ class DocumentLink(models.Model):
 
 
 class Result(models.Model):
-    activity = models.ForeignKey(Activity, related_name="result_set")
+    activity = models.ForeignKey(Activity, related_name="results")
     result_type = models.ForeignKey(ResultType, null=True, default=None)
     title = models.CharField(max_length=255, default="")
     description = models.TextField(default="")


### PR DESCRIPTION
This enables result__title search on activity lists / aggregations, as required by the unesco project to show focus area's. 

-possibility to filter /v3/activities by result__title
-aggregate-any group by result title
-country–geojson filter by result title
-add related_name to result model