### PR TITLE
fix bug in adding participating orgs

### DIFF
--- a/OIPA/iati/parser.py
+++ b/OIPA/iati/parser.py
@@ -762,7 +762,7 @@ class Parser():
                 ref = 'u'
 
             if models.Organisation.objects.filter(original_ref=ref, name=org_name).exists():
-                found_org = models.Organisation.objects.get(original_ref=ref, name=org_name)
+                found_org = models.Organisation.objects.filter(original_ref=ref, name=org_name)[0]
 
             else:
                 # create new with random suffix


### PR DESCRIPTION
This fixes a bug in adding participating organisations to an activity. 

The bug:

error in find_or_create_organisation
get() returned more than one Organisation -- it returned 2!

This can occur since the same original_ref + name combo can now be reported twice;

-When the same reporting org is saved from the participating org relationship, before the reporting org exists -> we may not save an org on a non existing ref without a suffix
-When the reporting org is saved.

This is a flaw in the current way of saving organisations, I see no way to prevent this atm. Open for improvements..