### PR TITLE
Activate 'in' filter on results title

### DIFF
--- a/OIPA/api/v3/resources/activity_view_resources.py
+++ b/OIPA/api/v3/resources/activity_view_resources.py
@@ -156,7 +156,7 @@ class ActivityResultResource(ModelResource):
         include_resource_uri = False
         excludes = ['id']
         filtering = {
-            'title': 'exact',
+            'title': ('exact', 'in'),
         }
 
 


### PR DESCRIPTION
in api v3 activities / activity-list call, to make getting activities
by multiple result titles possible.