### PR TITLE
Allow CORS

### DIFF
--- a/OIPA/OIPA/settings.py
+++ b/OIPA/OIPA/settings.py
@@ -83,6 +83,7 @@ TEMPLATE_LOADERS = (
 )
 
 MIDDLEWARE_CLASSES = (
+    'corsheaders.middleware.CorsMiddleware',
     'django.middleware.common.CommonMiddleware',
     'django.contrib.sessions.middleware.SessionMiddleware',
     'django.middleware.csrf.CsrfViewMiddleware',
@@ -126,6 +127,7 @@ INSTALLED_APPS = (
     'indicator_unesco',
     'translation_model',
     'rest_framework',
+    'corsheaders',
     'django_otp',
     'django_otp.plugins.otp_static',
     'django_otp.plugins.otp_totp',
@@ -185,6 +187,8 @@ REST_FRAMEWORK = {
         'rest_framework.filters.SearchFilter',
     )
 }
+
+CORS_ORIGIN_ALLOW_ALL = True
 
 try:
     from local_settings import *

--- a/OIPA/OIPA/settings.py
+++ b/OIPA/OIPA/settings.py
@@ -189,6 +189,10 @@ REST_FRAMEWORK = {
 }
 
 CORS_ORIGIN_ALLOW_ALL = True
+CORS_URLS_REGEX = r'^/api/.*$'
+CORS_ALLOW_METHODS = (
+    'GET',
+)
 
 try:
     from local_settings import *

--- a/OIPA/requirements.txt
+++ b/OIPA/requirements.txt
@@ -25,3 +25,4 @@ django-otp
 django-otp-yubikey
 django-two-factor-auth
 git+git://github.com/gkuhn1/django-admin-multiupload.git
+django-cors-headers==1.0.0


### PR DESCRIPTION
This changes the way cross domain requests are handled in the DRF API. It makes it accept requests from all origins. This simplifies direct API access from Front-end users.

Also see:

http://www.django-rest-framework.org/topics/ajax-csrf-cors/