### PR TITLE
CountryList nested filters

### DIFF
--- a/OIPA/api/country/serializers.py
+++ b/OIPA/api/country/serializers.py
@@ -38,7 +38,6 @@ class CountrySerializer(DynamicFieldsModelSerializer):
 
     def get_filtered_activities(self, obj):
         # Circular imports!!!, must be refactored
-        from api.activity.serializers import ActivitySerializer
         from api.activity.filters import ActivityFilter
 
         activity_filter = ActivityFilter()
@@ -53,6 +52,7 @@ class CountrySerializer(DynamicFieldsModelSerializer):
         return final_activities
 
     def get_activities(self, obj):
+        from api.activity.serializers import ActivitySerializer
 
         serializer = ActivitySerializer(self.get_filtered_activities(obj),
                                         context={'request': self.context['request']},
@@ -62,7 +62,7 @@ class CountrySerializer(DynamicFieldsModelSerializer):
         return serializer.data
 
     def get_aggregations(self, obj):
-        fields = tuple(utils.query_params_from_context(self.context)['fields[aggregations]'].split(','))
+        fields = tuple(utils.query_params_from_context(self.context).get('fields[aggregations]', str()).split(','))
 
         serializer = AggregationsSerializer(
             self.get_filtered_activities(obj),

--- a/OIPA/api/country/serializers.py
+++ b/OIPA/api/country/serializers.py
@@ -5,6 +5,7 @@ from api.region.serializers import RegionSerializer
 from api.fields import JSONField
 from api.activity.aggregation import AggregationsSerializer
 
+from api.generics import utils
 from iati.models import Activity
 
 class CountrySerializer(DynamicFieldsModelSerializer):
@@ -28,17 +29,15 @@ class CountrySerializer(DynamicFieldsModelSerializer):
     polygon = JSONField()
     
     activities = serializers.SerializerMethodField()
-    # activities = serializers.HyperlinkedIdentityField(
-    #     view_name='country-activities')
     
     indicators = serializers.HyperlinkedIdentityField(
         view_name='country-indicators')
     cities = serializers.HyperlinkedIdentityField(view_name='country-cities')
   
-    aggregations = AggregationsSerializer(source='activity_set', fields=())
     aggregations = serializers.SerializerMethodField()
 
-    def get_activities(self, obj):
+    def get_filtered_activities(self, obj):
+        # Circular imports!!!, must be refactored
         from api.activity.serializers import ActivitySerializer
         from api.activity.filters import ActivityFilter
 
@@ -49,9 +48,13 @@ class CountrySerializer(DynamicFieldsModelSerializer):
         )
 
         final_activities = activity_filter.filter_queryset(country_activities,
-                                                           self.context['params'])
+                                                           utils.query_params_from_context(self.context))
 
-        serializer = ActivitySerializer(final_activities,
+        return final_activities
+
+    def get_activities(self, obj):
+
+        serializer = ActivitySerializer(self.get_filtered_activities(obj),
                                         context={'request': self.context['request']},
                                         fields=('url', 'id', 'title', 'total_budget'),
                                         many=True)
@@ -59,26 +62,14 @@ class CountrySerializer(DynamicFieldsModelSerializer):
         return serializer.data
 
     def get_aggregations(self, obj):
-        from api.activity.serializers import ActivitySerializer
-        from api.activity.filters import ActivityFilter
-
-        activity_filter = ActivityFilter()
-
-        country_activities = Activity.objects.all().filter(
-            recipient_country=obj
-        )
-
-        final_activities = activity_filter.filter_queryset(country_activities,
-                                                           self.context['params'])
-
-        # print(final_activities)
+        fields = tuple(utils.query_params_from_context(self.context)['fields[aggregations]'].split(','))
 
         serializer = AggregationsSerializer(
-            final_activities)
+            self.get_filtered_activities(obj),
+            fields=fields
+        )
 
         return serializer.data
-
-
 
     class Meta:
         model = geodata.models.Country

--- a/OIPA/api/country/serializers.py
+++ b/OIPA/api/country/serializers.py
@@ -5,6 +5,7 @@ from api.region.serializers import RegionSerializer
 from api.fields import JSONField
 from api.activity.aggregation import AggregationsSerializer
 
+from iati.models import Activity
 
 class CountrySerializer(DynamicFieldsModelSerializer):
     class BasicCitySerializer(serializers.ModelSerializer):
@@ -25,12 +26,59 @@ class CountrySerializer(DynamicFieldsModelSerializer):
     capital_city = BasicCitySerializer()
     location = JSONField(source='center_longlat.json')
     polygon = JSONField()
-    activities = serializers.HyperlinkedIdentityField(
-        view_name='country-activities')
+    
+    activities = serializers.SerializerMethodField()
+    # activities = serializers.HyperlinkedIdentityField(
+    #     view_name='country-activities')
+    
     indicators = serializers.HyperlinkedIdentityField(
         view_name='country-indicators')
     cities = serializers.HyperlinkedIdentityField(view_name='country-cities')
+  
     aggregations = AggregationsSerializer(source='activity_set', fields=())
+    aggregations = serializers.SerializerMethodField()
+
+    def get_activities(self, obj):
+        from api.activity.serializers import ActivitySerializer
+        from api.activity.filters import ActivityFilter
+
+        activity_filter = ActivityFilter()
+
+        country_activities = Activity.objects.all().filter(
+            recipient_country=obj
+        )
+
+        final_activities = activity_filter.filter_queryset(country_activities,
+                                                           self.context['params'])
+
+        serializer = ActivitySerializer(final_activities,
+                                        context={'request': self.context['request']},
+                                        fields=('url', 'id', 'title', 'total_budget'),
+                                        many=True)
+
+        return serializer.data
+
+    def get_aggregations(self, obj):
+        from api.activity.serializers import ActivitySerializer
+        from api.activity.filters import ActivityFilter
+
+        activity_filter = ActivityFilter()
+
+        country_activities = Activity.objects.all().filter(
+            recipient_country=obj
+        )
+
+        final_activities = activity_filter.filter_queryset(country_activities,
+                                                           self.context['params'])
+
+        # print(final_activities)
+
+        serializer = AggregationsSerializer(
+            final_activities)
+
+        return serializer.data
+
+
 
     class Meta:
         model = geodata.models.Country

--- a/OIPA/api/country/views.py
+++ b/OIPA/api/country/views.py
@@ -8,9 +8,10 @@ from api.indicator.views import IndicatorList
 from rest_framework.generics import ListAPIView
 from rest_framework.generics import RetrieveAPIView
 from api.country.filters import CountryFilter
+from api.generics.views import PassContextMixin
 
 
-class CountryList(ListAPIView):
+class CountryList(PassContextMixin, ListAPIView):
     """
     Returns a list of IATI Countries stored in OIPA.
 
@@ -48,15 +49,6 @@ class CountryList(ListAPIView):
     serializer_class = serializers.CountrySerializer
     filter_class = CountryFilter
     fields = ('url', 'code', 'name', 'activities')
-
-    def get_serializer_context(self):
-        print(self.request.GET)
-        return {
-            'request': self.request,
-            'params': self.request.GET
-        }
-    # def get_serializer_class(self):
-    #     return self.serializer_class
 
 class CountryDetail(RetrieveAPIView):
     """

--- a/OIPA/api/country/views.py
+++ b/OIPA/api/country/views.py
@@ -47,8 +47,16 @@ class CountryList(ListAPIView):
     queryset = geodata.models.Country.objects.all()
     serializer_class = serializers.CountrySerializer
     filter_class = CountryFilter
-    fields = ('url', 'code', 'name')
+    fields = ('url', 'code', 'name', 'activities')
 
+    def get_serializer_context(self):
+        print(self.request.GET)
+        return {
+            'request': self.request,
+            'params': self.request.GET
+        }
+    # def get_serializer_class(self):
+    #     return self.serializer_class
 
 class CountryDetail(RetrieveAPIView):
     """

--- a/OIPA/api/country/views.py
+++ b/OIPA/api/country/views.py
@@ -48,7 +48,7 @@ class CountryList(PassContextMixin, ListAPIView):
     queryset = geodata.models.Country.objects.all()
     serializer_class = serializers.CountrySerializer
     filter_class = CountryFilter
-    fields = ('url', 'code', 'name', 'activities')
+    fields = ('url', 'code', 'name')
 
 class CountryDetail(RetrieveAPIView):
     """

--- a/OIPA/api/generics/views.py
+++ b/OIPA/api/generics/views.py
@@ -1,0 +1,9 @@
+
+class PassContextMixin(object):
+    """
+    Pass request and params object to the serializer for sub-filtering
+    """
+    def get_serializer_context(self):
+        return {
+            'request': self.request
+        }

--- a/OIPA/iati/models.py
+++ b/OIPA/iati/models.py
@@ -560,6 +560,9 @@ class CountryBudgetItem(models.Model):
     percentage = models.DecimalField(max_digits=5, decimal_places=2, null=True, default=None)
     description = models.TextField(default="")
 
+    def __unicode__(self,):
+        return "%s - %s" % (self.activity, self.code)
+
 
 class ActivityRecipientRegion(models.Model):
     activity = models.ForeignKey(Activity)
@@ -688,6 +691,7 @@ class ResultIndicator(models.Model):
     baseline_year = models.IntegerField(max_length=4)
     baseline_value = models.CharField(max_length=100)
     comment = models.TextField(default="")
+    
     measure = models.ForeignKey(
         ResultIndicatorMeasure,
         null=True,


### PR DESCRIPTION
This is only enabled for the CountryList API at the moment, for testing. 

Problems:
1. Circular dependencies with ActivitySerialzer, therefore the ActivitySerializer is imported when called (cached by python). Obiously, this is a workaround.
2. Used filters dont get removed before passing to child. Could be a problem when having filters with the same name in different views (can get removed when passing to child serializer)